### PR TITLE
Add console executable (base/diec.exe) to die

### DIFF
--- a/bucket/die.json
+++ b/bucket/die.json
@@ -12,6 +12,7 @@
     "extract_dir": "die_win32_portable",
     "bin": [
         "die.exe",
-        "diel.exe"
+        "diel.exe",
+        "base\\diec.exe"
     ]
 }


### PR DESCRIPTION
As die.exe and diel.exe are just wrappers for the .exes in the `base` directory, this would be even better:
```
    "bin": [
        "base\\die.exe",
        "base\\diel.exe",
        "base\\diec.exe"
    ]
```
