### PR TITLE
pestudio: Fix hash @9.14

### DIFF
--- a/bucket/pestudio.json
+++ b/bucket/pestudio.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.winitor.com",
     "description": "pestudio is used by Computer Emergency Response Teams and Labs worldwide in order to perform Malware Initial Assessment.",
     "version": "9.14",
-    "hash": "713b0b9b6a1dae0879b5043324427c9ca42b87dfdd35597fec9433966831d687",
+    "hash": "8706226296999bbd030e63bc44bbc70a3f07fe9df550afe129d88b4b72e7b0ca",
     "url": "https://winitor.com/tools/pestudio/current/pestudio.zip",
     "extract_dir": "pestudio",
     "bin": "pestudio.exe",


### PR DESCRIPTION
Fix mismatch hash of pestudio@9.14

```pwsh
Updating 'pestudio' (9.13 -> 9.14)
Downloading new version
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: a0ee94|OK  |   312KiB/s|D:/scoop/matsuoka/cache/pestudio#9.14#https_winitor.com_tools_pestudio_current_pestudio.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of pestudio.zip ... ERROR Hash check failed!
App:         retools/pestudio
URL:         https://winitor.com/tools/pestudio/current/pestudio.zip
First bytes: 50 4B 03 04 14 00 00 00
Expected:    713b0b9b6a1dae0879b5043324427c9ca42b87dfdd35597fec9433966831d687
Actual:      8706226296999bbd030e63bc44bbc70a3f07fe9df550afe129d88b4b72e7b0ca

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/TheCjw/scoop-retools/issues/new?title=pestudio%409.14%3a+hash+check+failed
```